### PR TITLE
Handle new scope name for C++

### DIFF
--- a/lib/build-lint.coffee
+++ b/lib/build-lint.coffee
@@ -5,7 +5,7 @@ path = require 'path'
 msgs = require './message-list.coffee'
 
 class LinterBuildTools extends Linter
-  @syntax: ['source.c++']
+  @syntax: ['source.c++', 'source.cpp']
 
   cmd: ''
   regex: ''


### PR DESCRIPTION
In the next release of Atom (v0.166), the scope name for C++ will change from `source.c++` to `source.cpp`. This is being done to work around some issues with CSS classes containing '+' characters. This PR adds handling for the new scope names, but will continue to handle the old ones, for compatibility with old versions of Atom.

Refs atom/language-c#54.
