### PR TITLE
UI for local configuration files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,3 +9,7 @@ script: 'curl -s https://raw.githubusercontent.com/atom/ci/master/build-package.
 
 git:
   depth: 10
+
+branches:
+  only:
+    - master

--- a/lib/local-settings-view.coffee
+++ b/lib/local-settings-view.coffee
@@ -35,7 +35,7 @@ module.exports =
       @commandpane?.destroy()
       @commandpane = null
       @projects = null
-      @project.destroy?()
+      @project?.destroy()
       @project = null
       @profiles = null
       @activepane = null

--- a/lib/local-settings-view.coffee
+++ b/lib/local-settings-view.coffee
@@ -22,6 +22,8 @@ module.exports =
         @showCommandPane()
         @commandpane.show arg0, arg1, arg2, arg3
       )
+      $(@projectpane.children()[1].children[0]).remove()
+      $(@projectpane.children()[1].children[1]).remove()
       @commandpane = new CommandPane(@projectpane.editccb, @hideCommandPane)
       @reload()
       return
@@ -33,6 +35,7 @@ module.exports =
       @commandpane?.destroy()
       @commandpane = null
       @projects = null
+      @project.destroy?()
       @project = null
       @profiles = null
       @activepane = null

--- a/lib/local-settings-view.coffee
+++ b/lib/local-settings-view.coffee
@@ -1,0 +1,75 @@
+{$, $$, View, TextEditorView} = require 'atom-space-pen-views'
+{CompositeDisposable} = require 'atom'
+_p = require 'path'
+
+ProjectPane = null
+CommandPane = null
+
+module.exports =
+  class LocalSettingsView extends View
+    projectpane: null
+    commandpane: null
+    activepane: null
+
+    @content: ->
+      @div class: 'settings pane-item', tabindex: -1, =>
+        @div class: 'panel padded', outlet: 'pane'
+
+    initialize: ({@uri, @projects, @project, @profiles}) ->
+      ProjectPane ?= require './project-pane'
+      CommandPane ?= require './command-pane'
+      @projectpane = new ProjectPane(@projects, @profiles, (arg0, arg1, arg2, arg3) =>
+        @showCommandPane()
+        @commandpane.show arg0, arg1, arg2, arg3
+      )
+      @commandpane = new CommandPane(@projectpane.editccb, @hideCommandPane)
+      @reload()
+      return
+
+    destroy: ->
+      @detach()
+      @projectpane?.destroy()
+      @projectpane = null
+      @commandpane?.destroy()
+      @commandpane = null
+      @projects = null
+      @project = null
+      @profiles = null
+      @activepane = null
+
+    attached: ->
+      @filechange = @project?.onFileChange @reload
+
+    detached: ->
+      @filechange?.dispose()
+      @filechange = null
+
+    getURI: ->
+      @uri
+
+    getTitle: ->
+      'Local Build Tools Settings'
+
+    getIconName: ->
+      'tools'
+
+    showProjectPane: ->
+      if @activepane isnt @projectpane
+        @activepane?.detach()
+        @pane.html @projectpane
+        @activepane = @projectpane
+
+    showCommandPane: ->
+      if @activepane isnt @commandpane
+        @activepane?.detach()
+        @pane.html @commandpane
+        @activepane = @commandpane
+
+    hideCommandPane: =>
+      @showProjectPane()
+
+    reload: =>
+      return unless @projects?
+      @projectpane.hideModals()
+      @showProjectPane()
+      @projectpane.setContent @project, _p.resolve(@uri, '..')

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -63,11 +63,6 @@ module.exports =
     if atom.config.get('build-tools.CloseOnSuccess') is -1
       atom.config.set('build-tools.CloseOnSuccess', 3)
     createConsoleView()
-    atom.workspace.addOpener (uritoopen) =>
-      if uritoopen is settingsviewuri
-        createSettingsView({uri: uritoopen, @projects, profiles: Profiles})
-      else if uritoopen.endsWith('.build-tools.cson') and (project = Projects.loadLocalFile uritoopen)?
-        createLocalSettingsView({uri: uritoopen, @projects, project, profiles: Profiles})
 
     @subscriptions = new CompositeDisposable
     @subscriptions.add atom.commands.add 'atom-workspace',
@@ -85,6 +80,11 @@ module.exports =
       'core:close': => @cancel()
     @subscriptions.add atom.project.onDidChangePaths ->
       settingsview?.reload()
+    @subscriptions.add atom.workspace.addOpener (uritoopen) =>
+      if uritoopen is settingsviewuri
+        createSettingsView({uri: uritoopen, @projects, profiles: Profiles})
+      else if uritoopen.endsWith('.build-tools.cson') and (project = Projects.loadLocalFile uritoopen)?
+        createLocalSettingsView({uri: uritoopen, @projects, project, profiles: Profiles})
 
   deactivate: ->
     @process?.kill()
@@ -102,6 +102,9 @@ module.exports =
     settingsview?.destroy()
     settingsview = null
     SettingsView = null
+    localsettingsview?.destroy()
+    localsettingsview = null
+    LocalSettingsView = null
     @projects?.destroy()
     @Projects = null
     @projects = null

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -8,6 +8,9 @@ settingsviewuri = 'atom://build-tools-settings'
 SettingsView = null
 settingsview = null
 
+LocalSettingsView = null
+localsettingsview = null
+
 ConsoleView = null
 consoleview = null
 
@@ -36,6 +39,11 @@ createSettingsView = (state) ->
   settingsview = new SettingsView(state)
   settingsview
 
+createLocalSettingsView = (state) ->
+  LocalSettingsView ?= require './local-settings-view'
+  localsettingsview = new LocalSettingsView(state)
+  localsettingsview
+
 module.exports =
 
   process: null
@@ -58,6 +66,8 @@ module.exports =
     atom.workspace.addOpener (uritoopen) =>
       if uritoopen is settingsviewuri
         createSettingsView({uri: uritoopen, @projects, profiles: Profiles})
+      else if uritoopen.endsWith('.build-tools.cson') and (project = Projects.loadLocalFile uritoopen)?
+        createLocalSettingsView({uri: uritoopen, @projects, project, profiles: Profiles})
 
     @subscriptions = new CompositeDisposable
     @subscriptions.add atom.commands.add 'atom-workspace',

--- a/lib/project.coffee
+++ b/lib/project.coffee
@@ -1,6 +1,9 @@
 Command = require './command'
 Dependency = require './dependency'
 
+CSON = null
+path = null
+
 module.exports =
   class Project
     path: ''
@@ -11,6 +14,12 @@ module.exports =
     key: {}
 
     constructor: (@path, {commands, dependencies, key}, @save, @check) ->
+      if not @save?
+        @save = =>
+          CSON ?= require 'season'
+          path ?= require 'path'
+          CSON.writeFileSync path.join(@path, '.build-tools.cson'), this
+      @check = null if not @check?
       if key?
         @key = key
       else

--- a/lib/project.coffee
+++ b/lib/project.coffee
@@ -27,7 +27,7 @@ module.exports =
           preconfigure: null
       @commands = []
       for command in commands
-        command.project ?= @path
+        command.project = @path if not command.project? or not @check?
         @commands.push(new Command(command))
       @dependencies = []
       if dependencies?

--- a/lib/project.coffee
+++ b/lib/project.coffee
@@ -7,12 +7,6 @@ Emitter = null
 
 module.exports =
   class Project
-    path: ''
-    commands: []
-    dependencies: []
-    save: null
-    check: null
-    key: {}
 
     constructor: (@path, {commands, dependencies, key}, @save, @check) ->
       if not @save?
@@ -21,9 +15,9 @@ module.exports =
         {Emitter} = require 'atom'
         @emitter = new Emitter
         @save = =>
-          CSON.writeFileSync path.join(@path, '.build-tools.cson'), this
+          CSON.writeFileSync path.join(@path, '.build-tools.cson'), {@commands}
           @emitter.emit 'file-change'
-      @check = null if not @check?
+      @check = undefined if not @check?
       if key?
         @key = key
       else
@@ -44,7 +38,7 @@ module.exports =
 
     destroy: ->
       @emitter?.dispose()
-      @emitter = null
+      @emitter = undefined
 
     notify: (message) ->
       atom.notifications?.addError message

--- a/lib/projects.coffee
+++ b/lib/projects.coffee
@@ -193,3 +193,10 @@ module.exports =
       catch error
         notify 'Error while reading settings from local file ' + path.join(_path, '.build-tools.cson')
         null
+
+    @loadLocalFile: (_path) ->
+      try
+        new Project(path.resolve(_path, '..'), CSON.readFileSync(_path))
+      catch error
+        notify 'Error while reading settings from local file ' + _path
+        null

--- a/snippets/build-tools.cson
+++ b/snippets/build-tools.cson
@@ -32,7 +32,7 @@
         'lint': false #Lint errors/warnings
       'stderr':
         'file': false
-        'highlighting': 'hc'
+        'highlighting': 'nh'
         'lint': false
       #Backwards compatibility with older command versions (don't change it)
       'version': 2

--- a/spec/fixtures/.build-tools.cson
+++ b/spec/fixtures/.build-tools.cson
@@ -22,7 +22,7 @@
       'lint': false #Lint errors/warnings
     'stderr':
       'file': false
-      'highlighting': 'hc'
+      'highlighting': 'nh'
       'lint': false
     #Backwards compatibility with older command versions (don't change it)
     'version': 2
@@ -50,7 +50,7 @@
       'lint': false #Lint errors/warnings
     'stderr':
       'file': false
-      'highlighting': 'hc'
+      'highlighting': 'nh'
       'lint': false
     #Backwards compatibility with older command versions (don't change it)
     'version': 2

--- a/spec/fixtures/.build-tools.cson
+++ b/spec/fixtures/.build-tools.cson
@@ -1,58 +1,42 @@
-'commands': [
+commands: [
   {
-    'name': 'Test'
-    'command': 'echo Hello World'
-    'wd': '.' #Working directory. Default: .
-    'shell': false #Execute in shell
-    'wildcards': false #Replace wildcards
-    'save_all': false #Save all
-    'close_success': false #Close console on success
-    'stdout':
-      'file': false #Highlight files
-      #nh: No highlighting
-      #ha: Highlight all
-      #ht: Highlight tags
-      #hc: Highlighting profile (requires 'profile')
-      'highlighting': 'nh'
-      #gcc_clang: GCC/Clang
-      #apm_test: apm test (Jasmine specs)
-      #java: Java
-      #python: Python
-      #'profile': 'gcc_clang' #Uncomment if 'highlighting' is 'hc'
-      'lint': false #Lint errors/warnings
-    'stderr':
-      'file': false
-      'highlighting': 'nh'
-      'lint': false
-    #Backwards compatibility with older command versions (don't change it)
-    'version': 2
+    project: "/home/fabian/.atom/packages/build-tools/spec/fixtures"
+    name: "Test"
+    command: "echo Hello World"
+    wd: "."
+    shell: false
+    wildcards: false
+    save_all: false
+    close_success: false
+    stdout:
+      file: false
+      highlighting: "nh"
+      lint: false
+    stderr:
+      file: false
+      highlighting: "nh"
+      lint: false
+    targetOf: []
+    version: 2
   }
   {
-    'name': 'Test 2'
-    'command': 'echo 2'
-    'wd': 'test' #Working directory. Default: .
-    'shell': false #Execute in shell
-    'wildcards': false #Replace wildcards
-    'save_all': false #Save all
-    'close_success': false #Close console on success
-    'stdout':
-      'file': false #Highlight files
-      #nh: No highlighting
-      #ha: Highlight all
-      #ht: Highlight tags
-      #hc: Highlighting profile (requires 'profile')
-      'highlighting': 'nh'
-      #gcc_clang: GCC/Clang
-      #apm_test: apm test (Jasmine specs)
-      #java: Java
-      #python: Python
-      #'profile': 'gcc_clang' #Uncomment if 'highlighting' is 'hc'
-      'lint': false #Lint errors/warnings
-    'stderr':
-      'file': false
-      'highlighting': 'nh'
-      'lint': false
-    #Backwards compatibility with older command versions (don't change it)
-    'version': 2
+    project: "/home/fabian/.atom/packages/build-tools/spec/fixtures"
+    name: "Test 2"
+    command: "echo 2"
+    wd: "."
+    shell: false
+    wildcards: false
+    save_all: false
+    close_success: false
+    stdout:
+      file: false
+      highlighting: "nh"
+      lint: false
+    stderr:
+      file: false
+      highlighting: "nh"
+      lint: false
+    targetOf: []
+    version: 2
   }
 ]

--- a/spec/local-settings-spec.coffee
+++ b/spec/local-settings-spec.coffee
@@ -1,0 +1,26 @@
+LocalSettingsView = require '../lib/local-settings-view'
+Profiles = require '../lib/profiles/profiles'
+Projects = require '../lib/projects'
+
+describe 'Local settings page', ->
+  {project, view, fixturesPath, projects} = []
+
+  beforeEach ->
+    fixturesPath = atom.project.getPaths()[0]
+    project = Projects.loadLocal fixturesPath
+    projects = new Projects('')
+    expect(project).not.toBeNull()
+    view = new LocalSettingsView({uri: '.build-tools.cson', projects, project, profiles: Profiles})
+    jasmine.attachToDOM view.element
+
+  afterEach ->
+    view.destroy()
+    project.destroy()
+    projects.destroy()
+
+  describe 'When opening the file', ->
+    it 'opens the settings page', ->
+      expect(view.projectpane).toBeDefined()
+      expect(view.activepane).toEqual view.projectpane
+      expect(view.projectpane.children()[1].children.length).toBe 1
+      expect(view.filechange).toBeDefined()

--- a/spec/local-spec.coffee
+++ b/spec/local-spec.coffee
@@ -2,7 +2,7 @@ Projects = require '../lib/projects'
 path = require 'path'
 
 describe 'Local projects', ->
-  fixturesPath = ""
+  fixturesPath = ''
 
   describe 'Test @hasLocal', ->
     it 'returns true', ->
@@ -14,9 +14,10 @@ describe 'Local projects', ->
       fixturesPath = atom.project.getPaths()[0]
       project = Projects.loadLocal fixturesPath
       expect(project).not.toBeNull()
+      expect(project.save).toBeDefined()
       expect(project.commands.length).toBe 2
       expect(project.commands[0].project).toBe fixturesPath
       expect(project.commands[0].name).toBe 'Test'
       expect(project.commands[0].command).toBe 'echo Hello World'
-      expect(project.commands[0].stderr.highlighting).toBe 'hc'
+      expect(project.commands[0].stderr.highlighting).toBe 'nh'
       expect(project.commands[0].version).toBe 2


### PR DESCRIPTION
This is a work-in-progress PR which provides a UI for local configuration files (introduced in [v3.4.0](https://github.com/deprint/build-tools-cpp/blob/master/CHANGELOG.md#340---local-configuration-files))

Works:
* Open UI by clicking on local config file
* Add/Edit/Remove commands

WIP:
* Hide dependency and key binding pane because they are not supported (DONE)
* Save file without unnecessary keys (DONE)
* Clean-up (DONE)
* Activate package on start-up just to support local config files ? (Will be added in later service implementations)
