### PR TITLE
Swap mentions of u/o key maps call command

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,10 +25,10 @@ build-tools
 6. Execute your command through one of the key bindings.
 
 ## Keys
-* `ctrl+l ctrl+u/i/o` for executing the 1st/2nd/3rd command of a project
+* `ctrl+l ctrl+o/i/u` for executing the 1st/2nd/3rd command of a project
 * `ctrl+l ctrl+l` to list all commands of a project
 * `ctrl+l ctrl+s` to show console output
-* `ctrl+l u/i/o` lets you view and change the command before executing it
+* `ctrl+l o/i/u` lets you view and change the command before executing it
 
 ## Service API
 `build-tools` allows other packages to:

--- a/keymaps/build-tools.cson
+++ b/keymaps/build-tools.cson
@@ -1,8 +1,8 @@
 'atom-workspace':
-  'ctrl-l ctrl-u': 'build-tools:third-command'
-  'ctrl-l ctrl-i': 'build-tools:second-command'
   'ctrl-l ctrl-o': 'build-tools:first-command'
-  'ctrl-l u': 'build-tools:third-command-ask'
-  'ctrl-l i': 'build-tools:second-command-ask'
+  'ctrl-l ctrl-i': 'build-tools:second-command'
+  'ctrl-l ctrl-u': 'build-tools:third-command'
   'ctrl-l o': 'build-tools:first-command-ask'
+  'ctrl-l i': 'build-tools:second-command-ask'
+  'ctrl-l u': 'build-tools:third-command-ask'
   'ctrl-l ctrl-l': 'build-tools:commands'


### PR DESCRIPTION
A minor change to clarify the documentation.

The documentation says: 'ctrl+l ctrl+u/i/o for executing the
1st/2nd/3rd'. Someone would think with 'ctrl+l ctrl+u' will execute 1st
command, when actually executes 3rd command.

Also, this commit swap u/o key map definitions. I guess this little
confusion got from there.