### PR TITLE
Fix hard keymapping of console toggle

### DIFF
--- a/keymaps/build-tools.cson
+++ b/keymaps/build-tools.cson
@@ -1,4 +1,5 @@
 'atom-workspace':
+  'ctrl-l ctrl-s': 'build-tools:toggle'
   'ctrl-l ctrl-o': 'build-tools:first-command'
   'ctrl-l ctrl-i': 'build-tools:second-command'
   'ctrl-l ctrl-u': 'build-tools:third-command'

--- a/lib/output/console.coffee
+++ b/lib/output/console.coffee
@@ -46,7 +46,6 @@ module.exports =
           consolepanel.hide()
         else
           consolepanel.show()
-    @disposables.add atom.keymaps.add 'build-tools:console', 'atom-workspace': 'ctrl-l ctrl-s': 'build-tools:toggle'
 
   deactivate: ->
     consolepanel.destroy()


### PR DESCRIPTION
I was unable to disable the keybinding for toggling the console through the settings. Had a look at your code and came up with this quick fix.

This once again allows me to select lines with ctrl+l without conflicts.